### PR TITLE
Fix the declaration of max30102_plot()

### DIFF
--- a/max30102_for_stm32_hal.c
+++ b/max30102_for_stm32_hal.c
@@ -14,7 +14,8 @@ extern "C"
  */
 __weak void max30102_plot(uint32_t ir_sample, uint32_t red_sample)
 {
-    
+    UNUSED(ir_sample);
+    UNUSED(red_sample);
 }
 
 /**

--- a/max30102_for_stm32_hal.h
+++ b/max30102_for_stm32_hal.h
@@ -119,7 +119,7 @@ typedef struct max30102_t
     uint8_t _interrupt_flag;
 } max30102_t;
 
-__weak void max30102_plot(uint32_t ir_sample, uint32_t red_sample);
+void max30102_plot(uint32_t ir_sample, uint32_t red_sample);
 
 void max30102_init(max30102_t *obj, I2C_HandleTypeDef *hi2c);
 void max30102_write(max30102_t *obj, uint8_t reg, uint8_t *buf, uint16_t buflen);


### PR DESCRIPTION
Thank you for your contribution to the HAL driver for the MAX30102, But there's a little flaw here that "__weak declaration" should  not appear in header files.

Otherwise, when we try to override max30102_plot() in a source file containing `#include "max30102_for_stm32_hal.h"`, a compiler warning will be triggered, as shown:

![2023-01-03_101044](https://user-images.githubusercontent.com/31568606/210325541-00efc67a-08f9-41f6-9cd9-be2d41715d7d.png)


Moreover, in actual use, the function will not be successfully overwritten, as shown in the figure:

![2023-01-03_101212](https://user-images.githubusercontent.com/31568606/210325591-675a0e47-a75a-45cb-b5b6-7eb31cc3ad9b.png)

In ST's HAL library, the function declaration in the header file does not contain "__weak", Take `HAL_GPIO_EXTI_Callback` for example, in ".c" file it has "__weak" declaration and in ".h" file it doesn't.

![2023-01-03_101352](https://user-images.githubusercontent.com/31568606/210326329-e5c91249-ae9b-4a1b-b5a8-96139054c7ba.png)
![2023-01-03_101447](https://user-images.githubusercontent.com/31568606/210326333-dec85885-be00-41da-bd51-e07efabada36.png)
